### PR TITLE
display unsupported ubuntu version message for versions 16.* and 17.*

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 #   DESTDIR = $prefix/lib/SUSI.AI       --prefix can be given
 #   BINDIR  = $prefix/bin
 #   WORKDIR = ~/.SUSI.AI
-#   
+#
 #   In system mode the susi-server starts as user $SUSI_SERVER_USER
 #   which defaults to _susiserver and can be configured via --susi-server-user
 #
@@ -89,7 +89,6 @@ case "$vendor" in
     Ubuntu)
         case "$version" in
             18.*|19.*|20.*) isBuster=1 ;;
-            16.*|17.*) ;;
             *) echo "Unsupported Ubuntu version: $version" >&2 ; exit 1 ;;
         esac
         ;;


### PR DESCRIPTION
Fixes #3

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [x] The unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- shows `Unsupported Ubuntu version: verison_number` for ubuntu versions < 18.xx
