### PR TITLE
Changed susi_linux repo to susi_installer

### DIFF
--- a/docs/ubuntu_install.md
+++ b/docs/ubuntu_install.md
@@ -28,8 +28,8 @@ Tested on:
 
 - Clone the Github Repository and open folder
 ```
-$ git clone https://github.com/fossasia/susi_linux.git
-$ cd susi_linux
+$ git clone https://github.com/fossasia/susi_installer
+$ cd susi_installer
 ```
 - Run the install script
 ````bash


### PR DESCRIPTION
No install.sh in susi_linux. Think they meant susi_installer

Fixes #11 

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)
