### PR TITLE
factory reset rework: soft, hard, and switch to ap mode support

### DIFF
--- a/docs/factory_resets.md
+++ b/docs/factory_resets.md
@@ -1,8 +1,18 @@
 # Factory Resets
 [Factory Reset](../factory_reset/factory_reset.py)
 
-Currently, our factory reset is configured on the GPIO port 17 of the Raspberry Pi, i.e. when the button configured to the port 17 or the one connected on the ReSpeaker Pi Hat is pressed for longer than 7 seconds, the factory reset [script](../factory_reset/factory_reset.sh) which moves the backup version of the software and deletes the original file.
+Currently, our factory reset is configured on the GPIO port 17 of the Raspberry Pi, i.e. when the button configured to the port 17 or the one connected on the ReSpeaker Pi Hat is pressed long enough, one of three actions is taken:
 
-## Future RoadMap
-Deleting everything from the Speaker System is a very hard and robust way of reset-ing the speaker.
-We expect to create a Soft Reset, which just uninstalls the packages and the local-server and re-installs them and hence providing a softer way of reset.
+- Press between 7 and 15 seconds: the speaker is switched to access point mode.
+  This is necessary in case the WLAN SSID has changed, or was misconfigured.
+- Press between 15 and 25 seconds: a soft reset is executed, which restores the original
+  software, but keeps configuration and server data.
+- Press longer than 25 seconds: a hard reset is performed, the unit is reset to the original state.
+
+## Developer information
+
+The factory reset daemon is implemented in [factory_reset.py](../raspi/factory_reset/factory_reset.py).
+Depending on the time the button was hold, either the [wap.sh](../raspi/access_point/wap.sh) is called,
+or the [factory_reset.sh](../raspi/factory_reset/factory_reset.sh).
+
+

--- a/raspi/access_point/rwap.sh
+++ b/raspi/access_point/rwap.sh
@@ -5,10 +5,6 @@ if [ "$EUID" -ne 0 ]
 	exit
 fi
 
-# stop and disable hostapd, it cannot run once we have set up wifi
-# and would be re-enabled in wap.sh if necessary
-systemctl stop hostapd
-systemctl disable hostapd
 
 cd /etc/hostapd/
 cp hostapd.conf hostapd.conf.bak
@@ -17,12 +13,14 @@ sed -i '1,14d' hostapd.conf
 rm -f /etc/network/interfaces.d/wlan-hostap
 cp /etc/network/interfaces.d/wlan.client /etc/network/interfaces.d/wlan-client
 
-#Empty port 5000
-#Remove the server file from auto-boot
+# systemctl unit setup
+# these are dual to wap.sh
+systemctl disable hostapd
+systemctl disable dnsmasq
 sudo systemctl enable ss-susi-linux@pi.service
-sudo systemctl disable ss-python-flask.service
 sudo systemctl enable ss-susi-login.service
+sudo systemctl disable ss-python-flask.service
 
 echo "Please reboot"
 sleep 10;
-sudo reboot
+reboot

--- a/raspi/access_point/wap.sh
+++ b/raspi/access_point/wap.sh
@@ -36,10 +36,15 @@ sed -i -- 's/#DAEMON_CONF=""/DAEMON_CONF="\/etc\/hostapd\/hostapd.conf"/g' /etc/
 rm -f /etc/network/interfaces.d/wlan-client
 cp /etc/network/interfaces.d/wlan.hostap /etc/network/interfaces.d/wlan-hostap
 
+# systemctl unit setup
+# these are dual to rwap.sh
 systemctl enable hostapd
 systemctl enable dnsmasq
+systemctl disable ss-susi-linux@pi.service
+systemctl disable ss-susi-login.service
+systemctl enable ss-python-flask.service
 
 # add server in the auto-boot up list
 echo "All done! Rebooting"
 
-sudo reboot
+reboot

--- a/raspi/factory_reset/factory_reset.py
+++ b/raspi/factory_reset/factory_reset.py
@@ -7,12 +7,12 @@ import RPi.GPIO as GPIO
 
 logger = logging.getLogger(__name__)
 current_folder = os.path.dirname(os.path.abspath(__file__))
-factory_reset = '/home/pi/SUSI.AI/susi_linux/factory_reset/factory_reset.sh'
+factory_reset = current_folder + '/factory_reset.sh'
+wap_script = os.path.abspath(current_folder + '/../access_point/wap.sh')
 
 try:
     GPIO.setmode(GPIO.BCM)
     GPIO.setup(17, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-    i = 1
     while True:
         if GPIO.input(17) == 1:
             time.sleep(0.2)
@@ -23,9 +23,18 @@ try:
                 time.sleep(0.2)
             end = time.time()
             total = end - start
-            if total >= 10 :
-                print("FACTORY RESET")
-                subprocess.Popen(['sudo','bash', factory_reset])
+            if total >= 25 :
+                print("hard FACTORY RESET")
+                logger.info("hard factory reset initiated")
+                subprocess.Popen(['sudo','bash', factory_reset, 'hard'])
+            elif total >= 15 :
+                print("soft FACTORY RESET")
+                logger.info("soft factory reset initiated")
+                subprocess.Popen(['sudo','bash', factory_reset, 'soft'])
+            elif total >= 7 :
+                print("switch to access point mode")
+                logger.info("switch to access mode initiated")
+                subprocess.Popen(['sudo','bash', wap_script])
             logger.info(total)
             time.sleep(0.2)
 

--- a/raspi/factory_reset/factory_reset.sh
+++ b/raspi/factory_reset/factory_reset.sh
@@ -1,6 +1,13 @@
 #! /bin/bash
 
-echo "running factory reset process"
+mode="$1"
+
+if [ -z "$mode" ] ; then
+  echo "No mode given, not doing factory reset. Pass in 'soft' or 'hard'" >&2
+  exit 1
+fi
+
+echo "running $mode factory reset process"
 
 # stop running processes
 # killall python3
@@ -18,11 +25,15 @@ mv /home/pi/SUSI.AI.NEW /home/pi/SUSI.AI
 
 # rescue the rescue dump before cleaning up
 echo "rescuing the rescue folder"
-mv /home/pi/SUSI.AI.OLD/susi_installer/raspi/factory_reset/reset_folder.tar.xz /home/pi/SUSI.AI/susi__installer/raspi/factory_reset/
+mv /home/pi/SUSI.AI.OLD/susi_installer/raspi/factory_reset/reset_folder.tar.xz /home/pi/SUSI.AI/susi_installer/raspi/factory_reset/
 
 # rescue config file 
 # TODO we can provide options for full reset and partial reset
-cp /home/pi/SUSI.AI.OLD/config.json /home/pi/SUSI.AI/
+if [ $mode = soft ] ; then
+  cp -a /home/pi/SUSI.AI.OLD/config.json /home/pi/SUSI.AI/
+  cp -a /home/pi/SUSI.AI.OLD/etherpad.db /home/pi/SUSI.AI/
+  cp -a /home/pi/SUSI.AI.OLD/susi_server_data /home/pi/SUSI.AI/
+fi
 
 # clean up
 echo "cleaning up"


### PR DESCRIPTION
The action that can be triggered with the button on the head are now split into three levels:
- level 1: press more than 7 secs but less than 15 secs
	switch the speaker to access point mode in case of a wifi misconfiguration
- level 2: press more than 15 secs and less than 25 secs
	make a soft reset, keeping settings (config.json, etherpad, server data)
- level 3: press more than 25 secs
	make a hard reset

Additional changes:
- do not use apt-get to update/install hostap in wap.sh, we don't want to do this during factory reset, we might not have internet access. Instead, add hostap and dnsmasq during image generation.
- documentation of the factory reset mode is adjusted