### PR TITLE
install usbmount

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -257,10 +257,11 @@ if [[ ( $targetSystem = debian && ! $targetVersion = 9 ) \
    ]]  ; then
   DEBDEPS="$DEBDEPS python3-alsaaudio"
 fi
- 
+
 # we need hostapd and dnsmask for access point mode
+# usbmount is needed to automount usb drives on susibian(raspbian lite)
 if [ $targetSystem = raspi ] ; then
-  DEBDEPS="$DEBDEPS hostapd dnsmasq"
+  DEBDEPS="$DEBDEPS hostapd dnsmasq usbmount"
 fi
 
 # add necessary dependencies for Coral device
@@ -268,7 +269,7 @@ if [ $CORAL = 1 ] ; then
     DEBDEPS="$DEBDEPS $CORALDEPS"
 fi
 
-# support external triggers in Travis builds, 
+# support external triggers in Travis builds,
 TRIGGER_BRANCH=${TRIGGER_BRANCH:-""}
 TRIGGER_SOURCE=${TRIGGER_SOURCE:-""}
 if [[ ( -n $TRIGGER_SOURCE ) && ( -n $TRIGGER_BRANCH ) ]] ; then
@@ -356,7 +357,7 @@ if [ "$INSTALLERDIR" != "$DESTDIR/susi_installer" ] ; then
     INSTALLERDIR="$DESTDIR/susi_installer"
 fi
 
-    
+
 # Set up default sudo mode
 # on Raspi and in system mode, use sudo
 # Otherwise leave empty so that user is asked whether to use it
@@ -483,7 +484,7 @@ install_pip_dependencies()
             ask_for_sudo
         fi
     fi
-    
+
     PIP=pip3
     if [ $CLEAN = 1 ] ; then
         PIP="pip3 --no-cache-dir"
@@ -695,6 +696,7 @@ if [ $targetSystem = raspi ]
 then
     echo "Updating the Udev Rules"
     sudo bash $INSTALLERDIR/raspi/media_daemon/media_udev_rule.sh
+    sudo sed -i 's/slave/shared/' /lib/systemd/system/systemd-udevd.service
 fi
 
 # systemd files rework

--- a/install.sh
+++ b/install.sh
@@ -696,7 +696,10 @@ if [ $targetSystem = raspi ]
 then
     echo "Updating the Udev Rules"
     sudo bash $INSTALLERDIR/raspi/media_daemon/media_udev_rule.sh
+    # systemd-udevd creates its own filesystem namespace, so mount is done, but it is not visible in the principal namespace.
     sudo sed -i 's/slave/shared/' /lib/systemd/system/systemd-udevd.service
+    # readonly mount for external USB drives
+    sudo sed '/^MOUNTOPTIONS/ s/sync/ro/' /etc/usbmount/usbmount.conf
 fi
 
 # systemd files rework

--- a/install.sh
+++ b/install.sh
@@ -697,7 +697,8 @@ then
     echo "Updating the Udev Rules"
     sudo bash $INSTALLERDIR/raspi/media_daemon/media_udev_rule.sh
     # systemd-udevd creates its own filesystem namespace, so mount is done, but it is not visible in the principal namespace.
-    sudo sed -i 's/slave/shared/' /lib/systemd/system/systemd-udevd.service
+    sudo mkdir /etc/systemd/system/systemd-udevd.service.d/
+    echo -e "[Service]\nMountFlags=shared" | sudo tee /etc/systemd/system/systemd-udevd.service.d/mountFlagOverride.conf
     # readonly mount for external USB drives
     sudo sed '/^MOUNTOPTIONS/ s/sync/ro/' /etc/usbmount/usbmount.conf
 fi


### PR DESCRIPTION
Fixes #20

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [x] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
Raspbian lite(on which susibian is based) doesn't automount USB drives, Mounting is required in order for the media-daemon to work for USB audio playback. Added usbmount to mount usb drives automatically.
