### PR TITLE
Media daemon rework

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -696,9 +696,10 @@ fi
 
 if [ $targetSystem = raspi ]
 then
-    echo "Updating the Udev Rules for media daemon"
+    echo "Updating the Udev Rules for media daemon and polkit localauthority"
     mkdir -p /etc/udev/rules.d
     sudo cp $INSTALLERDIR/raspi/media_daemon/99-susi-usb-drive.rules /etc/udev/rules.d
+    sudo cp $INSTALLERDIR/raspi/media_daemon/01-allow-plugdev-mount.pkla /etc/polkit-1/localauthority/50-local.d/
 
     echo "Installing RPi specific Systemd Rules"
     sudo bash $INSTALLERDIR/raspi/Deploy/auto_boot.sh
@@ -774,6 +775,11 @@ if [ $targetSystem = raspi ] ; then
     # enable the server service unconditionally
     sudo systemctl enable ss-susi-server
     sudo systemctl enable ss-etherpad-lite
+
+    # we need UTF8 char encoding, otherwise files with UTF8 names cannot
+    # be dealt with in Python
+    echo "Setting default locale to en_GB.UTF8"
+    echo "LC_ALL=en_GB.UTF8" | sudo tee -a /etc/environment
 
     echo "Enabling the SSH access"
     sudo systemctl enable ssh

--- a/install.sh
+++ b/install.sh
@@ -231,7 +231,7 @@ DEBDEPS="
   libportaudio2 libatlas3-base libpulse0 libasound2 vlc-bin vlc-plugin-base
   vlc-plugin-video-splitter python3-cairo python3-flask flite
   default-jdk-headless pixz udisks2 python3-requests python3-service-identity
-  python3-pyaudio python3-levenshtein python3-pafy python3-colorlog
+  python3-pyaudio python3-levenshtein python3-pafy python3-colorlog python3-psutil
   python3-watson-developer-cloud ca-certificates
 "
 

--- a/raspi/media_daemon/auto_skills.py
+++ b/raspi/media_daemon/auto_skills.py
@@ -64,7 +64,9 @@ def make_skill(): # pylint-enable
         music_path.append("{}".format(flac))
     for wav in wav_files:
         music_path.append("{}".format(wav))
-    song_list = " ".join( map ( lambda x: "file://" + x, music_path ) )
+    # we choose ; as separation char since this seems not to be used in
+    # any normal file system path naming
+    song_list = ";".join( map ( lambda x: "file://" + x, music_path ) )
     # TODO format of the skill looks strange!!!
     skills = ['play audio','!console:Playing audio from your usb device','{"actions":[','{"type":"audio_play", "identifier_type":"url", "identifier":"' + str(song_list) +'"}',']}','eol']
     for skill in skills:

--- a/raspi/media_daemon/auto_skills.py
+++ b/raspi/media_daemon/auto_skills.py
@@ -64,9 +64,9 @@ def make_skill(): # pylint-enable
         music_path.append("{}".format(flac))
     for wav in wav_files:
         music_path.append("{}".format(wav))
-    song_list = " ".join(music_path)
+    song_list = " ".join( map ( lambda x: "file://" + x, music_path ) )
     # TODO format of the skill looks strange!!!
-    skills = ['play audio','!console:Playing audio from your usb device','{"actions":[','{"type":"audio_play", "identifier_type":"url", "identifier":"file://'+str(song_list) +'"}',']}','eol']
+    skills = ['play audio','!console:Playing audio from your usb device','{"actions":[','{"type":"audio_play", "identifier_type":"url", "identifier":"' + str(song_list) +'"}',']}','eol']
     for skill in skills:
         f.write(skill + '\n')
     f.close()

--- a/raspi/media_daemon/auto_skills.py
+++ b/raspi/media_daemon/auto_skills.py
@@ -16,7 +16,6 @@ media_daemon_folder = os.path.dirname(os.path.abspath(__file__))
 base_folder = os.path.dirname(os.path.dirname(os.path.dirname(media_daemon_folder)))
 server_skill_folder = os.path.join(base_folder, 'susi_server/data/generic_skills/media_discovery')
 server_settings_folder = os.path.join(base_folder, 'susi_server/data/settings')
-server_restart_script = os.path.join(base_folder, 'susi_server/bin/restart.sh')
 
 def list_media_partitions():
     with open("/proc/partitions", "r") as f:
@@ -74,7 +73,7 @@ def make_skill(): # pylint-enable
     shutil.move(os.path.join(media_daemon_folder, 'custom_skill.txt'), server_skill_folder)
     with open(os.path.join(server_settings_folder, 'customized_config.properties'), 'a') as f2:
         f2.write('local.mode = true')
-    subprocess.call(['sudo', 'bash', server_restart_script])  #nosec #pylint-disable type: ignore
+    subprocess.call(['sudo', 'systemctl', 'restart', 'ss-susi-server'])  #nosec #pylint-disable type: ignore
 
 if __name__ == '__main__':
     make_skill()

--- a/raspi/media_daemon/autostart.sh
+++ b/raspi/media_daemon/autostart.sh
@@ -8,7 +8,8 @@ DIR_PATH=$(dirname $SCRIPT_PATH)
 if [ -d "$DIR_PATH/../../../susi_server" ]
 then
     cd $DIR_PATH
-    python3 auto_skills.py
+    # DEVNAME is exported from the udevd on the start/stop script
+    python3 auto_skills.py "$DEVNAME"
 else
     echo "Please download Skill Data"
 fi 

--- a/raspi/media_daemon/autostart.sh
+++ b/raspi/media_daemon/autostart.sh
@@ -1,7 +1,5 @@
 #! /bin/bash
 
-clear
-
 SCRIPT_PATH=$(realpath $0)
 DIR_PATH=$(dirname $SCRIPT_PATH)
 
@@ -9,7 +7,7 @@ if [ -d "$DIR_PATH/../../../susi_server" ]
 then
     cd $DIR_PATH
     # DEVNAME is exported from the udevd on the start/stop script
-    python3 auto_skills.py "$DEVNAME"
+    sudo -u pi python3 auto_skills.py "$DEVNAME"
 else
     echo "Please download Skill Data"
 fi 

--- a/raspi/media_daemon/autostop.sh
+++ b/raspi/media_daemon/autostop.sh
@@ -5,4 +5,7 @@ DIR_PATH=$(dirname $SCRIPT_PATH)
 
 cd $DIR_PATH/../../../susi_server/data/generic_skills/media_discovery/
  
-sudo rm custom_skill.txt 
+sudo rm -f custom_skill.txt
+
+exit 0
+


### PR DESCRIPTION
This series of patches reworks the media daemon operation

- support usb sticks with partitions
- mount as user pi instead of root, and generate skills as user pi
- install a localauthority file allowing the user to mount the devices
- set default locale to en_GB.UTF8 to make sure character encodings are correctly written with Python3
- use systemctl to restart the server instead of script
- mount all the partitions of the currently plugged device
- don't mount other partitions
- mount ro
- recursively search for audio files
