### PR TITLE
Add restart to vlcplayer and soundserver

### DIFF
--- a/soundserver/soundserver.py
+++ b/soundserver/soundserver.py
@@ -92,6 +92,11 @@ def previous_route():
     vlcplayer.previous()
     return do_return('Ok', 200)
 
+@app.route('/restart', methods=['GET'])
+def restart_route():
+    vlcplayer.restart()
+    return do_return('Ok', 200)
+
 @app.route('/save_softvolume', methods=['GET'])
 def save_softvolume_route():
     vlcplayer.save_softvolume()

--- a/vlcplayer/__init__.py
+++ b/vlcplayer/__init__.py
@@ -55,6 +55,12 @@ class VlcPlayer():
         if self.is_playing():
             self.list_player.previous()
 
+    def restart(self):
+        if self.is_playing():
+            self.list_player.previous()
+            time.sleep(0.01)
+            self.list_player.next()
+
     def pause(self):
         if self.is_playing():
             self.list_player.pause()


### PR DESCRIPTION
Fixes #25

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- Added restart option to the sound server and vlcplayer
- The 'restart' option will restart the currently playing audio