### PR TITLE
Adding shuffle method to vlc player

### DIFF
--- a/soundserver/soundserver.py
+++ b/soundserver/soundserver.py
@@ -97,6 +97,11 @@ def restart_route():
     vlcplayer.restart()
     return do_return('Ok', 200)
 
+@app.route('/shuffle', methods=['GET'])
+def shuffle_route():
+    vlcplayer.shuffle()
+    return do_return('Ok', 200)
+
 @app.route('/save_softvolume', methods=['GET'])
 def save_softvolume_route():
     vlcplayer.save_softvolume()

--- a/vlcplayer/__init__.py
+++ b/vlcplayer/__init__.py
@@ -3,6 +3,7 @@
 import vlc
 import pafy
 import time
+import random
 from hwmixer import mixer
 
 #
@@ -41,8 +42,8 @@ class VlcPlayer():
         self.play(vid2youtubeMRL(vid))
 
     def play(self, mrl_string):
-        mrl = mrl_string.split(";")
-        media_list = self.instance.media_list_new(mrl)
+        self.mrl = mrl_string.split(";")
+        media_list = self.instance.media_list_new(self.mrl)
         self.list_player.set_media_list(media_list)
         self.list_player.play()
         self.softvolume(100, self.player)
@@ -60,6 +61,15 @@ class VlcPlayer():
             self.list_player.previous()
             time.sleep(0.01)
             self.list_player.next()
+
+    def shuffle(self):
+        if self.is_playing():
+            self.list_player.stop()
+            random.shuffle(self.mrl)
+            media_list = self.instance.media_list_new(self.mrl)
+            self.list_player.set_media_list(media_list)
+            self.list_player.play()
+            self.softvolume(100, self.player)
 
     def pause(self):
         if self.is_playing():


### PR DESCRIPTION
Fixes #30

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [x] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- Add shuffle method to vlcplayer and soundserver
- When shuffle is called it should shuffle the currently playing playlist
#### Changes proposed in this pull request:
