### PR TITLE
Add various levels of authorization to the soundserver [WIP]

### DIFF
--- a/raspi/soundserver/pass.txt
+++ b/raspi/soundserver/pass.txt
@@ -1,0 +1,1 @@
+default

--- a/raspi/soundserver/pass.txt
+++ b/raspi/soundserver/pass.txt
@@ -1,1 +1,1 @@
-default
+defaultsdaf

--- a/raspi/soundserver/pass.txt
+++ b/raspi/soundserver/pass.txt
@@ -1,1 +1,1 @@
-defaultsdaf
+default

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -1,5 +1,6 @@
 from flask import Flask , render_template , request, flash, redirect, session, abort, g, url_for
 from flask import jsonify
+from werkzeug.security import generate_password_hash, check_password_hash
 import sys
 import os
 from vlcplayer import vlcplayer
@@ -14,17 +15,17 @@ def do_return(msg, val):
     resp.status_code = val
     return resp
 
-def check_pass(passw=None):
+def check_pass(passw=''):
     f=open(dir_path+'/pass.txt', "r")
     get_pass = f.readline().splitlines()[0]
-    if (passw==None and get_pass=='default') or (passw==get_pass):
+    if (passw=='' and get_pass=='default') or (check_password_hash(get_pass,passw)):
         return True
     else:
         return False
 
-def write_pass(passw=None):
+def write_pass(passw):
     fw=open(dir_path+"/pass.txt","w+")
-    fw.write(passw)
+    fw.write(str(generate_password_hash(passw)))
     session['logged_in'] = False
 
 @app.before_request

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -1,4 +1,4 @@
-from flask import Flask , render_template , request, flash, redirect, session, abort
+from flask import Flask , render_template , request, flash, redirect, session, abort, g, url_for
 from flask import jsonify
 import sys
 import os
@@ -14,16 +14,22 @@ def do_return(msg, val):
     resp.status_code = val
     return resp
 
+@app.before_request
+def before_request_callback():
+    if request.endpoint != 'login' and request.endpoint != 'login_index' and stored_token!='default' and not session.get('logged_in') and request.remote_addr != '127.0.0.1':
+        return redirect('/login_page')
+
 @app.route('/')
 def index():
-    if stored_token!='default' and not session.get('logged_in'):
-        return render_template('login.html')
-    else:
-        return render_template('index.html')
+    return render_template('index.html')
+
+@app.route('/login_page')
+def login_index():
+    return render_template('login.html')
 
 @app.route('/login', methods=['POST', 'PUT'])
 def login():
-    if request.form['password'] == 'password':
+    if request.form['password'] == stored_token:
         session['logged_in'] = True
     else:
         flash('wrong password!')

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -6,6 +6,7 @@ from vlcplayer import vlcplayer
 
 app = Flask(__name__)
 f=open("pass.txt", "r")
+stored_token = f.readline().splitlines()[0]
 
 def do_return(msg, val):
     dm = {"status": msg}
@@ -15,8 +16,7 @@ def do_return(msg, val):
 
 @app.route('/')
 def index():
-    stored_token = str(f.read())
-    if not session.get('logged_in'):
+    if stored_token!='default' and not session.get('logged_in'):
         return render_template('login.html')
     else:
         return render_template('index.html')

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -1,10 +1,11 @@
-from flask import Flask , render_template , request
+from flask import Flask , render_template , request, flash, redirect, session, abort
 from flask import jsonify
 import sys
 import os
 from vlcplayer import vlcplayer
 
 app = Flask(__name__)
+f=open("pass.txt", "r")
 
 def do_return(msg, val):
     dm = {"status": msg}
@@ -14,10 +15,14 @@ def do_return(msg, val):
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    stored_token = str(f.read())
+    if not session.get('logged_in') and stored_token=='default':
+        return render_template('login.html')
+    else:
+        return render_template('index.html')
 
 @app.route('/login')
-def index():
+def login():
     return render_template('login.html')
 
 @app.route('/status', methods=['POST', 'PUT'])

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -16,14 +16,18 @@ def do_return(msg, val):
 @app.route('/')
 def index():
     stored_token = str(f.read())
-    if not session.get('logged_in') and stored_token=='default':
+    if not session.get('logged_in'):
         return render_template('login.html')
     else:
         return render_template('index.html')
 
-@app.route('/login')
+@app.route('/login', methods=['POST', 'PUT'])
 def login():
-    return render_template('login.html')
+    if request.form['password'] == 'password':
+        session['logged_in'] = True
+    else:
+        flash('wrong password!')
+    return index()
 
 @app.route('/status', methods=['POST', 'PUT'])
 def status_route():
@@ -127,4 +131,5 @@ def restore_hardvolume_route():
 
 
 if __name__ == '__main__':
+    app.secret_key = os.urandom(12)
     app.run(debug=False, port=7070, host='0.0.0.0')

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -5,7 +5,9 @@ import os
 from vlcplayer import vlcplayer
 
 app = Flask(__name__)
-f=open("pass.txt", "r")
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+f=open(dir_path+'/pass.txt', "r")
 stored_token = f.readline().splitlines()[0]
 
 def do_return(msg, val):

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -30,7 +30,7 @@ def write_pass(passw=None):
 @app.before_request
 def before_request_callback():
     if request.endpoint != 'login' and request.endpoint != 'static' and not\
-       check_pass() and not session.get('logged_in'):
+       check_pass() and not session.get('logged_in') and request.remote_addr != '127.0.0.1':
         return render_template('login.html')
 
 @app.route('/')

--- a/raspi/soundserver/soundserver.py
+++ b/raspi/soundserver/soundserver.py
@@ -16,6 +16,10 @@ def do_return(msg, val):
 def index():
     return render_template('index.html')
 
+@app.route('/login')
+def index():
+    return render_template('login.html')
+
 @app.route('/status', methods=['POST', 'PUT'])
 def status_route():
     return do_return('Ok', 200)

--- a/raspi/soundserver/templates/index.html
+++ b/raspi/soundserver/templates/index.html
@@ -56,6 +56,11 @@
           			<i class="fas fa-stop"></i>
           		</button>
           </fieldset>
+          <button onclick="window.location.href = '/set_password';" class="btn btn-warning m-2">
+            Set or Change Password
+            <i class="fa fa-key"></i>
+          </button>
+
         </div>
     </div>
     <script>

--- a/raspi/soundserver/templates/login.html
+++ b/raspi/soundserver/templates/login.html
@@ -6,8 +6,16 @@
     <title>SUSI AI Smart Speaker Control</title>
     <link href="{{ url_for('static', filename='bootstrap.min.css') }}" rel="stylesheet">
     <link href="{{ url_for('static', filename='signin.css') }}" rel="stylesheet">
-    <script type="text/javascript" src="{{ url_for('static', filename='fontawesome.min.js') }}"></script>
   </head>
+
+  <form class="form-signin" action="/login" method="POST">
+    <div class="form-group">
+      <img class="mb-4" src="{{ url_for('static', filename='SUSI.AI_Icon_2017a.svg') }}" alt="" width="256" height="256">
+      <label for="password">Password</label>
+      <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </form>
 
   <body class="text-center">
 

--- a/raspi/soundserver/templates/login.html
+++ b/raspi/soundserver/templates/login.html
@@ -10,8 +10,8 @@
 
   <form class="form-signin" action="/login" method="POST">
     <div class="form-group">
-      <img class="mb-4" src="{{ url_for('static', filename='SUSI.AI_Icon_2017a.svg') }}" alt="" width="256" height="256">
-      <label for="password">Password</label>
+      <img class="mb-4" src="{{ url_for('static', filename='SUSI.AI_Icon_2017a.svg') }}" alt="" width="256" height="256"> </br>
+      <h2>Password</h2>
       <input type="password" class="form-control" id="password" name="password" placeholder="Password">
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>

--- a/raspi/soundserver/templates/login.html
+++ b/raspi/soundserver/templates/login.html
@@ -11,7 +11,7 @@
   <form class="form-signin" action="/login" method="POST">
     <div class="form-group">
       <img class="mb-4" src="{{ url_for('static', filename='SUSI.AI_Icon_2017a.svg') }}" alt="" width="256" height="256"> </br>
-      <h2>Password</h2>
+      <h2>Enter Your Password To Continue</h2>
       <input type="password" class="form-control" id="password" name="password" placeholder="Password">
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>

--- a/raspi/soundserver/templates/login.html
+++ b/raspi/soundserver/templates/login.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>SUSI AI Smart Speaker Control</title>
+    <link href="{{ url_for('static', filename='bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='signin.css') }}" rel="stylesheet">
+    <script type="text/javascript" src="{{ url_for('static', filename='fontawesome.min.js') }}"></script>
+  </head>
+
+  <body class="text-center">
+
+  </body>
+</html>

--- a/raspi/soundserver/templates/password.html
+++ b/raspi/soundserver/templates/password.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>SUSI AI Smart Speaker Control</title>
+    <link href="{{ url_for('static', filename='bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='signin.css') }}" rel="stylesheet">
+  </head>
+
+  <form class="form-signin" action="/set_password" method="POST">
+    <div class="form-group">
+      <img class="mb-4" src="{{ url_for('static', filename='SUSI.AI_Icon_2017a.svg') }}" alt="" width="256" height="256"> </br>
+      <h2>Enter Your New Password</h2>
+      <input type="Text" class="form-control" id="password" name="password" placeholder="Password">
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </form>
+
+  <body class="text-center">
+
+  </body>
+</html>


### PR DESCRIPTION
Fixes #

This PR adds authorization to the sound server in such a way that -
- Localhost doesn't need authorisation i.e. connections within the device doesn't need to authorise
- By default there is no password, opening the sound control webpage doesn't require password nor the endpoints 
- The user has the option to set up a password if needed. If the password is set, a login screen appears before the smart speaker control webpage and all the endpoints only work if the user is authorised
