### PR TITLE
Volume control on raspberry pi when using audio jack on repseaker hat

### DIFF
--- a/pythonmods/hwmixer/__init__.py
+++ b/pythonmods/hwmixer/__init__.py
@@ -9,7 +9,7 @@ class HwMixer():
     def __init__(self):
         self.mixerid = ''
         for i in alsaaudio.mixers():
-            if i == 'Master' or i == 'PCM' or i == 'Speaker':
+            if i == 'Master' or i == 'PCM' or i == 'Speaker' or i == 'Playback':
                 self.mixerid = i
         if self.mixerid == '':
             raise Exception('Cannot find mixer')


### PR DESCRIPTION
Fixes #38

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- Add `playback` mixer control to hwmixer