### PR TITLE
fix usb auto mount

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -756,7 +756,7 @@ then
     echo "Preparing USB automount"
     # systemd-udevd creates its own filesystem namespace, so mount is done, but it is not visible in the principal namespace.
     sudo mkdir /etc/systemd/system/systemd-udevd.service.d/
-    echo -e "[Service]\nMountFlags=shared" | sudo tee /etc/systemd/system/systemd-udevd.service.d/mountFlagOverride.conf
+    echo -e "[Service]\nPrivateMounts=no" | sudo tee /etc/systemd/system/systemd-udevd.service.d/udev-service-override.conf
     # readonly mount for external USB drives
     sudo sed -i -e '/^MOUNTOPTIONS/ s/sync/ro/' /etc/usbmount/usbmount.conf
     sudo cp $INSTALLERDIR/raspi/media_daemon/01_create_skill /etc/usbmount/mount.d/


### PR DESCRIPTION
Fixes #60

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [x] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
After changing release to use Raspbian buster, USB automount stopped working.
#### Changes proposed in this pull request:
Fix USB automount.
