### PR TITLE
Add endpoint to check whether the device is in access-point mode

### DIFF
--- a/raspi/controlserver/controlserver.py
+++ b/raspi/controlserver/controlserver.py
@@ -70,6 +70,16 @@ def setup():
     access_mode()
     return render_template('setup.html')
 
+#End-point to check whether the device is in access point mode
+@app.route('/check_ap')
+def check_ap_mode():
+    if access_mode():
+        dm = {"status": "True"}
+    else:
+        dm = {"status": "False"}
+    resp = jsonify(dm)
+    return resp
+
 @app.route('/login', methods=['POST', 'PUT'])
 def setlogin():
     if check_pass(request.form['password']):


### PR DESCRIPTION
Fixes #79

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
Add endpoint to the control server to  check whether the device is in access-point mode 
