### PR TITLE
Add additional WiFi Network credentials

### DIFF
--- a/raspi/access_point/add_wifi.sh
+++ b/raspi/access_point/add_wifi.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+SSID=""
+PSK=""
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Must be root"
+  exit
+fi
+
+if [[ $# -gt 0 ]]; then
+  SSID="$1"
+fi
+
+if [[ $# -gt 1 ]]; then
+  PSK="$2"
+fi
+
+if [[ -z $PSK ]]; then
+  echo "Adding open network $SSID"
+  cat >> /etc/wpa_supplicant/wpa_supplicant.conf <<EOF
+network={
+    ssid="$SSID"
+    key_mgmt=NONE
+}
+EOF
+  exit
+fi
+
+echo "Adding secure network $SSID"
+cat >> /etc/wpa_supplicant/wpa_supplicant.conf <<EOF
+network={
+    ssid="$SSID"
+    psk="$PSK"
+}
+EOF

--- a/raspi/controlserver/controlserver.py
+++ b/raspi/controlserver/controlserver.py
@@ -286,6 +286,16 @@ def wifi_config():
     resp.status_code = 200
     return resp  # pylint-enable
 
+@app.route('/add_wifi', methods=['GET'])
+def add_wifi():
+    wifi_ssid = request.args.get('wifissid')
+    wifi_password = request.args.get('wifipassd')
+    subprocess.call(['sudo', 'bash', wifi_search_folder + '/add_wifi.sh', wifi_ssid, wifi_password])  #nosec #pylint-disable type: ignore
+    display_message = {"wifi":"configured", "wifi_ssid":wifi_ssid, "wifi_password": wifi_password}
+    resp = jsonify(display_message)
+    resp.status_code = 200
+    return resp  # pylint-enable
+
 @app.route('/speaker_config', methods=['GET'])
 def speaker_config():
     room_name = request.args.get('room_name')


### PR DESCRIPTION
Fixes #85

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
* Add `add_wifi.sh` script for configuring additional WiFi credentials.
* Create `/add_wifi` endpoint in the control server
