### PR TITLE
Wakebutton

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -604,7 +604,7 @@ if [ ! -r "$CFG" ] ; then
   cat >"$CFG" <<EOF
 {
   "Device": "Desktop Computer",
-  "WakeButton": "not available",
+  "WakeButton": "enabled",
   "default_stt": "google",
   "default_tts": "google",
   "data_base_dir": "$DESTDIR/susi_linux",

--- a/raspi/controlserver/controlserver.py
+++ b/raspi/controlserver/controlserver.py
@@ -333,9 +333,8 @@ def reboot():
     stt = request.form['stt']
     tts = request.form['tts']
     hotword = request.form['hotword']
-    wake = request.form['wake']
-    subprocess.Popen(['sudo', '-u', 'pi', susiconfig, 'set', "stt="+stt, "tts="+tts, "hotword="+hotword, "wakebutton="+wake])  #nosec #pylint-disable type: ignore
-    display_message = {"wifi":"configured", "room_name":room_name, "wifi_ssid":wifi_ssid, "auth":auth, "email":email, "stt":stt, "tts":tts, "hotword":hotword, "wake":wake, "message":"SUSI is rebooting"}
+    subprocess.Popen(['sudo', '-u', 'pi', susiconfig, 'set', "stt="+stt, "tts="+tts, "hotword="+hotword])  #nosec #pylint-disable type: ignore
+    display_message = {"wifi":"configured", "room_name":room_name, "wifi_ssid":wifi_ssid, "auth":auth, "email":email, "stt":stt, "tts":tts, "hotword":hotword, "message":"SUSI is rebooting"}
     resp = jsonify(display_message)
     resp.status_code = 200
     subprocess.Popen(['sudo','bash', os.path.join(wifi_search_folder,'rwap.sh')])


### PR DESCRIPTION
Fixes #91

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- enable wake button by default in the installation script
- remove the wakebutton option from `/reboot` endpoint in the control server