### PR TITLE
Add local anonymous user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -674,6 +674,19 @@ echo "Downloading: Susi server"
 if [ ! -d susi_server ]
 then
     git clone -b stable-dist --single-branch https://github.com/fossasia/susi_server.git
+    # creating a local anonymous user with credentials:
+    # Username: anonymous@susi.ai and password: password
+    mkdir -p ./susi_server/data/settings/
+    cat > ./susi_server/data/settings/authentication.json <<EOL
+{
+  "passwd_login:anonymous@susi.ai": {
+    "salt": "i0Q9jnWLfRf4sRJN3svg",
+    "id": "email:anonymous@susi.ai",
+    "passwordHash": "+UarmkoElJhC6+RQdp7Cz1eYJ0Y0ebCCq8un4jYLpQ0=",
+    "activated": true
+  }
+}
+EOL
 else
     echo "WARNING: susi_server directory already present, not cloning it!" >&2
 fi


### PR DESCRIPTION
Fixes #95

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [x] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:
- Add a local user to the SUSI Server at the time of installation with the following credentials 
Username: anonymous@susi.ai
Password: password
