### PR TITLE
Fix location to install udev-restart-after-boot service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -893,7 +893,7 @@ if [ $targetSystem = raspi ] ; then
     # this is a recent change from udev somewhen in 2018?
     echo "Working around broken udev and ro file systems"
     sudo mkdir -p /etc/systemd/system
-    sudo cp $INSTALLERDIR/raspi/media_daemon/udev-restart-after-boot.service /etc/systemd/system/udev-restart-after-boot.service
+    sudo cp $INSTALLERDIR/raspi/media_daemon/udev-restart-after-boot.service /lib/systemd/system/
     sudo systemctl enable udev-restart-after-boot
 
     echo "Disable dhcpcd"


### PR DESCRIPTION

#### Checklist

- [x] I have read the Contribution & Best practices Guide and my PR follows them.
- [x] My branch is up-to-date with the Upstream master branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] All the functions created/modified in this PR contain relevant docstrings.

#### Test Passing

- [ ] The SUSI Server must be building on the pi on bootup
- [ ] The hotword detection should have a decent accuracy
- [ ] SUSI Linux shouldn't crash when switching from online to offline and vice versa (failing as of now)
- [ ] SUSI Linux should be able to boot offline when no internet connection available (failing)

#### Short description of what this resolves:

If we want to disable/enable service, the right location is _/lib/systemd/_

#### Changes proposed in this pull request:
