### PR TITLE
Fix openSUSE misspelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ on the system, in particular the following programs need to be available
 programs afterwards). The following table lists the required programs and
 the respective packages in Debian/Buster and Fedora 31:
 
-| Program | Debian/Ubuntu/Mint   | Fedora 31   | OpenSuSE Leap 15.1 |
+| Program | Debian/Ubuntu/Mint   | Fedora 31   | openSUSE Leap 15.1 |
 | ------- | -------------------- | ----------- | ------------------ |
 | git     | git                  | git         | git |
 | wget    | wget                 | wget        | wget |


### PR DESCRIPTION
The correct spelling of openSUSE can be checked on https://en.opensuse.org/Portal:Distribution

#### Short description of what this resolves:
This PR fixes the spelling of openSUSE.
#### Changes proposed in this pull request:
Make the spelling of openSUSE consistent and correct.